### PR TITLE
Es plugin fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,12 @@ prepare:
 deps:
 	go get -v github.com/vitkovskii/insane-doc@v0.0.1
 
+.PHONY: cover
+cover:
+	go test -coverprofile=coverage.out ./...
+	go tool cover -html=coverage.out
+	rm coverage.out
+
 .PHONY: test
 test:
 	go test ./fd/ -v -count 1

--- a/cmd/file.d.go
+++ b/cmd/file.d.go
@@ -86,7 +86,7 @@ func start() {
 }
 
 func listenSignals() {
-	signalChan := make(chan os.Signal)
+	signalChan := make(chan os.Signal, 1)
 	signal.Notify(signalChan, syscall.SIGHUP, syscall.SIGTERM)
 
 	for {

--- a/cmd/file.d_test.go
+++ b/cmd/file.d_test.go
@@ -107,7 +107,7 @@ func TestEndToEnd(t *testing.T) {
 
 func runWriter(tempDir string, files int) {
 	format := `{"log":"%s\n","stream":"stderr"}`
-	panicLines := make([]string, 0, 0)
+	panicLines := make([]string, 0)
 	for _, line := range strings.Split(panicContent, "\n") {
 		if line == "" {
 			continue

--- a/fd/file.d.go
+++ b/fd/file.d.go
@@ -1,6 +1,7 @@
 package fd
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -31,7 +32,7 @@ func New(config *cfg.Config, httpAddr string) *FileD {
 		config:    config,
 		httpAddr:  httpAddr,
 		plugins:   DefaultPluginRegistry,
-		Pipelines: make([]*pipeline.Pipeline, 0, 0),
+		Pipelines: make([]*pipeline.Pipeline, 0),
 	}
 }
 
@@ -239,7 +240,7 @@ func (f *FileD) getStaticInfo(pipelineConfig *cfg.PipelineConfig, pluginKind pip
 
 func (f *FileD) Stop() {
 	logger.Infof("stopping pipelines=%d", len(f.Pipelines))
-	_ = f.server.Shutdown(nil)
+	_ = f.server.Shutdown(context.TODO())
 	for _, p := range f.Pipelines {
 		p.Stop()
 	}

--- a/fd/util.go
+++ b/fd/util.go
@@ -102,7 +102,7 @@ func extractMatchInvert(actionJSON *simplejson.Json) (bool, error) {
 }
 
 func extractConditions(condJSON *simplejson.Json) (pipeline.MatchConditions, error) {
-	conditions := make(pipeline.MatchConditions, 0, 0)
+	conditions := make(pipeline.MatchConditions, 0)
 	for field := range condJSON.MustMap() {
 		value := condJSON.Get(field).MustString()
 

--- a/pipeline/batch.go
+++ b/pipeline/batch.go
@@ -40,7 +40,7 @@ func (b *Batch) append(e *Event) {
 func (b *Batch) isReady() bool {
 	l := len(b.Events)
 	isFull := l == b.size
-	isTimeout := l > 0 && time.Now().Sub(b.startTime) > b.timeout
+	isTimeout := l > 0 && time.Since(b.startTime) > b.timeout
 	return isFull || isTimeout
 }
 
@@ -117,13 +117,13 @@ type WorkerData interface{}
 
 func (b *Batcher) work() {
 	t := time.Now()
-	events := make([]*Event, 0, 0)
+	events := make([]*Event, 0)
 	data := WorkerData(nil)
 	for batch := range b.fullBatches {
 		b.outFn(&data, batch)
 		events = b.commitBatch(events, batch)
 
-		shouldRunMaintenance := b.maintenanceFn != nil && b.maintenanceInterval != 0 && time.Now().Sub(t) > b.maintenanceInterval
+		shouldRunMaintenance := b.maintenanceFn != nil && b.maintenanceInterval != 0 && time.Since(t) > b.maintenanceInterval
 		if shouldRunMaintenance {
 			t = time.Now()
 			b.maintenanceFn(&data)

--- a/pipeline/pipeline.go
+++ b/pipeline/pipeline.go
@@ -447,7 +447,7 @@ func (p *Pipeline) growProcs() {
 			t = time.Now()
 		}
 
-		if time.Now().Sub(t) > interval {
+		if time.Since(t) > interval {
 			p.expandProcs()
 		}
 	}

--- a/pipeline/processor.go
+++ b/pipeline/processor.go
@@ -87,7 +87,7 @@ func NewProcessor(
 		activeCounter: activeCounter,
 		actionWatcher: newActionWatcher(id),
 
-		metricsValues: make([]string, 0, 0),
+		metricsValues: make([]string, 0),
 	}
 
 	id++

--- a/pipeline/streamer.go
+++ b/pipeline/streamer.go
@@ -29,7 +29,7 @@ func newStreamer(eventTimeout time.Duration) *streamer {
 	streamer := &streamer{
 		streams: make(map[SourceID]map[StreamName]*stream),
 		mu:      &sync.RWMutex{},
-		charged: make([]*stream, 0, 0),
+		charged: make([]*stream, 0),
 
 		chargedMu: &sync.Mutex{},
 		blockedMu: &sync.Mutex{},
@@ -144,7 +144,7 @@ func (s *streamer) resetBlocked(stream *stream) {
 }
 
 func (s *streamer) heartbeat() {
-	streams := make([]*stream, 0, 0)
+	streams := make([]*stream, 0)
 	for {
 		time.Sleep(time.Millisecond * 200)
 		if s.shouldStop {

--- a/plugin/action/add_host/add_host_test.go
+++ b/plugin/action/add_host/add_host_test.go
@@ -16,7 +16,7 @@ func TestModify(t *testing.T) {
 	wg := &sync.WaitGroup{}
 	wg.Add(1)
 
-	outEvents := make([]*pipeline.Event, 0, 0)
+	outEvents := make([]*pipeline.Event, 0)
 	output.SetOutFn(func(e *pipeline.Event) {
 		outEvents = append(outEvents, e)
 		wg.Done()

--- a/plugin/action/convert_date/convert_date_test.go
+++ b/plugin/action/convert_date/convert_date_test.go
@@ -28,7 +28,7 @@ func TestConvert(t *testing.T) {
 		inEvents++
 	})
 
-	outEvents := make([]*pipeline.Event, 0, 0)
+	outEvents := make([]*pipeline.Event, 0)
 	output.SetOutFn(func(e *pipeline.Event) {
 		outEvents = append(outEvents, e)
 		wg.Done()
@@ -61,7 +61,7 @@ func TestConvertFail(t *testing.T) {
 		inEvents++
 	})
 
-	outEvents := make([]*pipeline.Event, 0, 0)
+	outEvents := make([]*pipeline.Event, 0)
 	output.SetOutFn(func(e *pipeline.Event) {
 		outEvents = append(outEvents, e)
 		wg.Done()

--- a/plugin/action/discard/discard_test.go
+++ b/plugin/action/discard/discard_test.go
@@ -33,7 +33,7 @@ func TestDiscardAnd(t *testing.T) {
 		inEvents++
 	})
 
-	outEvents := make([]*pipeline.Event, 0, 0)
+	outEvents := make([]*pipeline.Event, 0)
 	output.SetOutFn(func(e *pipeline.Event) {
 		wg.Done()
 		outEvents = append(outEvents, e)
@@ -77,7 +77,7 @@ func TestDiscardOr(t *testing.T) {
 		inEvents++
 	})
 
-	outEvents := make([]*pipeline.Event, 0, 0)
+	outEvents := make([]*pipeline.Event, 0)
 	output.SetOutFn(func(e *pipeline.Event) {
 		wg.Done()
 		outEvents = append(outEvents, e)
@@ -121,7 +121,7 @@ func TestDiscardRegex(t *testing.T) {
 		inEvents++
 	})
 
-	outEvents := make([]*pipeline.Event, 0, 0)
+	outEvents := make([]*pipeline.Event, 0)
 	output.SetOutFn(func(e *pipeline.Event) {
 		wg.Done()
 		outEvents = append(outEvents, e)
@@ -162,7 +162,7 @@ func TestDiscardMatchInvert(t *testing.T) {
 		inEvents++
 	})
 
-	outEvents := make([]*pipeline.Event, 0, 0)
+	outEvents := make([]*pipeline.Event, 0)
 	output.SetOutFn(func(e *pipeline.Event) {
 		wg.Done()
 		outEvents = append(outEvents, e)

--- a/plugin/action/flatten/flatten_test.go
+++ b/plugin/action/flatten/flatten_test.go
@@ -21,13 +21,13 @@ func TestFlatten(t *testing.T) {
 	p, input, output := test.NewPipelineMock(test.NewActionPluginStaticInfo(factory, config, pipeline.MatchModeAnd, nil, false))
 
 	wg := &sync.WaitGroup{}
-	acceptedEvents := make([]*pipeline.Event, 0, 0)
+	acceptedEvents := make([]*pipeline.Event, 0)
 	input.SetCommitFn(func(e *pipeline.Event) {
 		wg.Done()
 		acceptedEvents = append(acceptedEvents, e)
 	})
 
-	dumpedEvents := make([]*pipeline.Event, 0, 0)
+	dumpedEvents := make([]*pipeline.Event, 0)
 	output.SetOutFn(func(e *pipeline.Event) {
 		wg.Done()
 		dumpedEvents = append(dumpedEvents, e)

--- a/plugin/action/json_decode/json_decode_test.go
+++ b/plugin/action/json_decode/json_decode_test.go
@@ -27,7 +27,7 @@ func TestDecode(t *testing.T) {
 		inEvents++
 	})
 
-	outEvents := make([]*pipeline.Event, 0, 0)
+	outEvents := make([]*pipeline.Event, 0)
 	output.SetOutFn(func(e *pipeline.Event) {
 		outEvents = append(outEvents, e)
 		wg.Done()

--- a/plugin/action/keep_fields/keep_fields_test.go
+++ b/plugin/action/keep_fields/keep_fields_test.go
@@ -15,7 +15,7 @@ func TestKeepFields(t *testing.T) {
 	wg := &sync.WaitGroup{}
 	wg.Add(3)
 
-	outEvents := make([]*pipeline.Event, 0, 0)
+	outEvents := make([]*pipeline.Event, 0)
 	output.SetOutFn(func(e *pipeline.Event) {
 		outEvents = append(outEvents, e)
 		wg.Done()

--- a/plugin/action/modify/modify_test.go
+++ b/plugin/action/modify/modify_test.go
@@ -15,7 +15,7 @@ func TestModify(t *testing.T) {
 	wg := &sync.WaitGroup{}
 	wg.Add(1)
 
-	outEvents := make([]*pipeline.Event, 0, 0)
+	outEvents := make([]*pipeline.Event, 0)
 	output.SetOutFn(func(e *pipeline.Event) {
 		outEvents = append(outEvents, e)
 		wg.Done()

--- a/plugin/action/parse_es/parse_es.go
+++ b/plugin/action/parse_es/parse_es.go
@@ -80,7 +80,8 @@ func (p *Plugin) Do(event *pipeline.Event) pipeline.ActionResult {
 		return pipeline.ActionCollapse
 	}
 
-	p.logger.Fatalf("wrong ES input format, expected action, got: %s", root.EncodeToString())
+	// If request invalid skip bad event.
+	p.logger.Error("wrong ES input format, expected action, got: %s", root.EncodeToString())
 
 	return pipeline.ActionDiscard
 }

--- a/plugin/action/parse_es/parse_es_test.go
+++ b/plugin/action/parse_es/parse_es_test.go
@@ -1,0 +1,157 @@
+package parse_es
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	insaneJSON "github.com/vitkovskii/insane-json"
+	"go.uber.org/zap"
+
+	"github.com/ozonru/file.d/pipeline"
+)
+
+func TestDoTimeout(t *testing.T) {
+	log := zap.NewExample().Sugar()
+	p := &Plugin{logger: log}
+
+	event := pipeline.Event{}
+	event.SetTimeoutKind()
+
+	action := p.Do(&event)
+	assert.Equal(t, pipeline.ActionDiscard, action, "timeout action must be discarded, but it wasn't")
+}
+
+func TestDoCollapseDescribePanic(t *testing.T) {
+	log := zap.NewExample().Sugar()
+
+	p := &Plugin{logger: log}
+	p.discardNext = true
+	p.passNext = true
+
+	event := pipeline.Event{}
+
+	assert.Panics(t, func() { p.Do(&event) }, &event)
+}
+
+func TestDoPassAndDiscard(t *testing.T) {
+	type testCase struct {
+		name                  string
+		passNextStartState    bool
+		discardNextStartState bool
+
+		expectedAction        pipeline.ActionResult
+		passNextExpectedState bool
+		discardExpectedState  bool
+	}
+	cases := []testCase{
+		{
+			name:                  "pass_next",
+			passNextStartState:    true,
+			discardNextStartState: false,
+
+			expectedAction:        pipeline.ActionPass,
+			passNextExpectedState: false,
+			discardExpectedState:  false,
+		},
+
+		{
+			name:                  "discard_next",
+			passNextStartState:    false,
+			discardNextStartState: true,
+
+			expectedAction:        pipeline.ActionCollapse,
+			passNextExpectedState: false,
+			discardExpectedState:  false,
+		},
+	}
+
+	for _, tCase := range cases {
+		tCase := tCase
+		t.Run(tCase.name, func(t *testing.T) {
+			p := &Plugin{}
+			p.passNext = tCase.passNextStartState
+			p.discardNext = tCase.discardNextStartState
+
+			event := pipeline.Event{}
+
+			action := p.Do(&event)
+			assert.Equal(t, tCase.expectedAction, action)
+			assert.Equal(t, tCase.passNextExpectedState, p.passNext)
+			assert.Equal(t, tCase.discardExpectedState, p.discardNext)
+		})
+	}
+}
+
+func TestDo(t *testing.T) {
+	type testCase struct {
+		name    string
+		digName string
+
+		expectedAction        pipeline.ActionResult
+		passNextExpectedState bool
+		discardExpectedState  bool
+	}
+	cases := []testCase{
+		{
+			name:                  "request_delete",
+			digName:               "delete",
+			expectedAction:        pipeline.ActionCollapse,
+			passNextExpectedState: false,
+			discardExpectedState:  false,
+		},
+		{
+			name:                  "request_update",
+			digName:               "update",
+			expectedAction:        pipeline.ActionCollapse,
+			passNextExpectedState: false,
+			discardExpectedState:  true,
+		},
+		{
+			name:                  "request_index",
+			digName:               "index",
+			expectedAction:        pipeline.ActionCollapse,
+			passNextExpectedState: true,
+			discardExpectedState:  false,
+		},
+		{
+			name:                  "request_create",
+			digName:               "create",
+			expectedAction:        pipeline.ActionCollapse,
+			passNextExpectedState: true,
+			discardExpectedState:  false,
+		},
+	}
+
+	for _, tCase := range cases {
+		tCase := tCase
+		t.Run(tCase.name, func(t *testing.T) {
+			p := &Plugin{}
+			root := insaneJSON.Spawn()
+			defer insaneJSON.Release(root)
+
+			_ = root.AddField(tCase.digName)
+
+			event := pipeline.Event{Root: root}
+			action := p.Do(&event)
+			assert.Equal(t, tCase.expectedAction, action)
+			assert.Equal(t, tCase.passNextExpectedState, p.passNext)
+			assert.Equal(t, tCase.discardExpectedState, p.discardNext)
+		})
+	}
+}
+
+func TestDoDiscardBadRequest(t *testing.T) {
+	log := zap.NewExample().Sugar()
+	p := &Plugin{logger: log}
+
+	root := insaneJSON.Spawn()
+	defer insaneJSON.Release(root)
+
+	_ = root.AddField("bad_request_discard_me")
+
+	event := pipeline.Event{Root: root}
+	action := p.Do(&event)
+	assert.Equal(t, pipeline.ActionDiscard, action)
+	assert.Equal(t, false, p.passNext)
+	assert.Equal(t, false, p.discardNext)
+}

--- a/plugin/action/parse_es/pipeline_test.go
+++ b/plugin/action/parse_es/pipeline_test.go
@@ -1,0 +1,130 @@
+package parse_es
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/ozonru/file.d/cfg"
+	"github.com/ozonru/file.d/logger"
+	"github.com/ozonru/file.d/pipeline"
+	"github.com/ozonru/file.d/test"
+)
+
+func TestPipeline(t *testing.T) {
+	type eventIn struct {
+		sourceID   pipeline.SourceID
+		sourceName string
+		offset     int64
+		bytes      []byte
+	}
+
+	validMsg := `{"message":"valid_mgs_to_parse","kind":"normal"}`
+	invalidMsg := `BaDsYmBoLs{"message":"valid_mgs_to_parse","kind":"normal"}`
+
+	cases := []struct {
+		name           string
+		eventsIn       []eventIn
+		eventsInCount  int
+		eventsOutCount int
+		firstEventOut  string
+	}{
+		{
+			name: "wrong_events",
+			eventsIn: []eventIn{
+				{
+					sourceID:   pipeline.SourceID(1),
+					sourceName: "parse_es_test_source.log",
+					offset:     0,
+					bytes:      []byte(invalidMsg),
+				},
+				{
+					sourceID:   pipeline.SourceID(1),
+					sourceName: "parse_es_test_source.log",
+					offset:     0,
+					bytes:      []byte(invalidMsg),
+				},
+			},
+			eventsInCount:  2,
+			eventsOutCount: 0,
+		},
+		{
+			name: "correct_events",
+			eventsIn: []eventIn{
+				{
+					sourceID:   pipeline.SourceID(1),
+					sourceName: "parse_es_test_source.log",
+					offset:     0,
+					bytes:      []byte(validMsg),
+				},
+				{
+					sourceID:   pipeline.SourceID(1),
+					sourceName: "parse_es_test_source.log",
+					offset:     0,
+					bytes:      []byte(validMsg),
+				},
+			},
+			eventsInCount:  2,
+			eventsOutCount: 2,
+		},
+		{
+			name: "mixed_events",
+			eventsIn: []eventIn{
+				{
+					sourceID:   pipeline.SourceID(1),
+					sourceName: "parse_es_test_source.log",
+					offset:     0,
+					bytes:      []byte(validMsg),
+				},
+				{
+					sourceID:   pipeline.SourceID(1),
+					sourceName: "parse_es_test_source.log",
+					offset:     0,
+					bytes:      []byte(invalidMsg),
+				},
+			},
+			eventsInCount:  2,
+			eventsOutCount: 1,
+		},
+	}
+
+	for _, tCase := range cases {
+		tCase := tCase
+		t.Run(tCase.name, func(t *testing.T) {
+			config := &Config{}
+			p, input, output := test.NewPipelineMock(test.NewActionPluginStaticInfo(factory, config, pipeline.MatchModeOr, nil, false))
+
+			err := cfg.Parse(config, nil)
+			if err != nil {
+				logger.Panicf("wrong config")
+			}
+
+			wg := &sync.WaitGroup{}
+			wg.Add(tCase.eventsInCount)
+			wg.Add(tCase.eventsOutCount)
+
+			eventsIn := 0
+			input.SetInFn(func() {
+				wg.Done()
+				eventsIn++
+			})
+
+			outEvents := make([]*pipeline.Event, 0)
+			output.SetOutFn(func(e *pipeline.Event) {
+				wg.Done()
+				outEvents = append(outEvents, e)
+			})
+
+			for _, event := range tCase.eventsIn {
+				input.In(event.sourceID, event.sourceName, event.offset, event.bytes)
+			}
+
+			wg.Wait()
+			p.Stop()
+
+			assert.Equal(t, 2, eventsIn, "wrong eventsIn events count")
+			assert.Equal(t, tCase.eventsOutCount, len(outEvents), "wrong out events count")
+		})
+	}
+}

--- a/plugin/action/parse_re2/parse_re2_test.go
+++ b/plugin/action/parse_re2/parse_re2_test.go
@@ -31,7 +31,7 @@ func TestDecode(t *testing.T) {
 		inEvents++
 	})
 
-	outEvents := make([]*pipeline.Event, 0, 0)
+	outEvents := make([]*pipeline.Event, 0)
 	output.SetOutFn(func(e *pipeline.Event) {
 		outEvents = append(outEvents, e)
 		wg.Done()

--- a/plugin/action/remove_fields/remove_fields_test.go
+++ b/plugin/action/remove_fields/remove_fields_test.go
@@ -14,7 +14,7 @@ func TestRemoveFields(t *testing.T) {
 	wg := &sync.WaitGroup{}
 	wg.Add(3)
 
-	outEvents := make([]*pipeline.Event, 0, 0)
+	outEvents := make([]*pipeline.Event, 0)
 	output.SetOutFn(func(e *pipeline.Event) {
 		outEvents = append(outEvents, e)
 		wg.Done()

--- a/plugin/action/rename/rename_test.go
+++ b/plugin/action/rename/rename_test.go
@@ -22,7 +22,7 @@ func TestRename(t *testing.T) {
 	wg := &sync.WaitGroup{}
 	wg.Add(5)
 
-	outEvents := make([]*pipeline.Event, 0, 0)
+	outEvents := make([]*pipeline.Event, 0)
 	output.SetOutFn(func(e *pipeline.Event) {
 		outEvents = append(outEvents, e)
 		wg.Done()

--- a/plugin/input/file/file_test.go
+++ b/plugin/input/file/file_test.go
@@ -34,6 +34,8 @@ const (
 	offsetsFile = "offsets.yaml"
 	newLine     = 1
 	perm        = 0o770
+
+	strPrefix = `"_`
 )
 
 func TestMain(m *testing.M) {
@@ -244,13 +246,12 @@ func addLines(file string, from int, to int) int {
 	size := 0
 	for i := from; i < to; i++ {
 
-		str := fmt.Sprintf(`"_`)
-		if _, err = f.WriteString(str); err != nil {
+		if _, err = f.WriteString(strPrefix); err != nil {
 			panic(err.Error())
 		}
-		size += len(str)
+		size += len(strPrefix)
 
-		str = fmt.Sprintf(`%d"`+"\n", i)
+		str := fmt.Sprintf(`%d"`+"\n", i)
 		if _, err = f.WriteString(str); err != nil {
 			panic(err.Error())
 		}
@@ -401,7 +402,7 @@ func TestWatch(t *testing.T) {
 // TestReadSimple tests if file reading works right in the simple case
 func TestReadSimple(t *testing.T) {
 	eventCount := 5
-	events := make([]string, 0, 0)
+	events := make([]string, 0)
 
 	run(&test.Case{
 		Prepare: func() {
@@ -429,8 +430,8 @@ func TestReadContinue(t *testing.T) {
 	blockSize := 2000
 	stopAfter := 100
 	processed := 0
-	inputEvents := make([]string, 0, 0)
-	outputEvents := make([]string, 0, 0)
+	inputEvents := make([]string, 0)
+	outputEvents := make([]string, 0)
 	file := ""
 	size := 0
 
@@ -482,7 +483,7 @@ func TestReadContinue(t *testing.T) {
 // TestOffsetsSaveSimple tests if offsets saving works right in the simple case
 func TestOffsetsSaveSimple(t *testing.T) {
 	eventCount := 5
-	events := make([]string, 0, 0)
+	events := make([]string, 0)
 	file := ""
 	size := 0
 

--- a/plugin/input/file/offset.go
+++ b/plugin/input/file/offset.go
@@ -43,7 +43,7 @@ func newOffsetDB(curOffsetsFile string, tmpOffsetsFile string) *offsetDB {
 		mu:             &sync.Mutex{},
 		savesTotal:     &atomic.Int64{},
 		buf:            make([]byte, 0, 65536),
-		jobsSnapshot:   make([]*Job, 0, 0),
+		jobsSnapshot:   make([]*Job, 0),
 		reloadCh:       make(chan bool),
 	}
 }

--- a/plugin/input/file/offset_test.go
+++ b/plugin/input/file/offset_test.go
@@ -102,7 +102,7 @@ func TestParallel(t *testing.T) {
 	for i := 0; i < count; i++ {
 		go func() {
 			offsetDB := newOffsetDB("tests-offsets", "tests-offsets.tmp")
-			offsetDB.parse(data)
+			_, _ = offsetDB.parse(data)
 			offsetDB.save(jobs, rwmu)
 			wg.Done()
 		}()

--- a/plugin/input/file/provider.go
+++ b/plugin/input/file/provider.go
@@ -581,7 +581,6 @@ func (jp *jobProvider) maintenanceJob(job *Job) int {
 	isDone := job.isDone
 	filename := job.filename
 	file := job.file
-	inode := job.inode
 
 	if !isDone {
 		job.mu.Unlock()
@@ -618,7 +617,7 @@ func (jp *jobProvider) maintenanceJob(job *Job) int {
 
 	filename = job.filename
 	file = job.file
-	inode = job.inode
+	inode := job.inode
 
 	// try release file descriptor in the case file have been deleted
 	// for that reason just close it and immediately try to open

--- a/plugin/input/file/worker.go
+++ b/plugin/input/file/worker.go
@@ -27,7 +27,6 @@ func (w *worker) work(controller inputer, jobProvider *jobProvider, readBufferSi
 	var inBuffer []byte
 	shouldCheckMax := w.maxEventSize != 0
 
-	var seqID uint64 = 0
 	for {
 		job := <-jobProvider.jobsChan
 		if job == nil {
@@ -105,8 +104,7 @@ func (w *worker) work(controller inputer, jobProvider *jobProvider, readBufferSi
 					if shouldCheckMax && len(inBuffer) > w.maxEventSize {
 						break
 					}
-					seqID = controller.In(sourceID, sourceName, offset, inBuffer, isVirgin)
-					job.lastEventSeq = seqID
+					job.lastEventSeq = controller.In(sourceID, sourceName, offset, inBuffer, isVirgin)
 				}
 				accumBuffer = accumBuffer[:0]
 

--- a/plugin/input/http/README.md
+++ b/plugin/input/http/README.md
@@ -22,5 +22,53 @@ Which protocol to emulate.
 
 <br>
 
+**Example:**  
+Emulating elastic through http:
+```yaml
+pipelines:
+  example_k8s_pipeline:
+    settings:
+      capacity: 1024
+    input:
+      # define input type.
+      type: http
+      # pretend elastic search, emulate it's protocol.
+      emulate_mode: "elasticsearch"
+      # define http port.
+      address: ":9200"
+    actions:
+      # parse elastic search query.
+      - type: parse_es
+      # decode elastic search json.
+      - type: json_decode
+        # field is required.
+        field: message
+    output:
+      # Let's write to kafka example.
+      type: kafka
+        brokers: [kafka-local:9092, kafka-local:9091]
+        default_topic: yourtopic-k8s-data
+        use_topic_field: true
+        topic_field: pipeline_kafka_topic
+      
+      # Or we can write to file: 
+      # type: file
+      # target_file: "./output.txt"
+```
+
+Setup:
+```
+# run server. 
+# config.yaml should contains yaml config above. 
+go run cmd/file.d.go --config=config.yaml
+
+# now do requests.
+curl "localhost:9200/_bulk" -H 'Content-Type: application/json' -d \
+'{"index":{"_index":"index-main","_type":"span"}}
+{"message": "hello", "kind": "normal"}
+
+##
+ 
+```
 
 <br>*Generated using [__insane-doc__](https://github.com/vitkovskii/insane-doc)*

--- a/plugin/input/http/http.go
+++ b/plugin/input/http/http.go
@@ -73,7 +73,7 @@ func (p *Plugin) Start(config pipeline.AnyConfig, params *pipeline.InputPluginPa
 	p.mu = &sync.Mutex{}
 	p.controller = params.Controller
 	p.controller.DisableStreams()
-	p.sourceIDs = make([]pipeline.SourceID, 0, 0)
+	p.sourceIDs = make([]pipeline.SourceID, 0)
 
 	mux := http.NewServeMux()
 	switch p.config.EmulateMode {

--- a/plugin/input/http/http_test.go
+++ b/plugin/input/http/http_test.go
@@ -33,7 +33,7 @@ func TestProcessChunksMany(t *testing.T) {
 	wg := &sync.WaitGroup{}
 	wg.Add(3)
 
-	outEvents := make([]string, 0, 0)
+	outEvents := make([]string, 0)
 	output.SetOutFn(func(event *pipeline.Event) {
 		outEvents = append(outEvents, event.Root.EncodeToString())
 		wg.Done()
@@ -43,7 +43,7 @@ func TestProcessChunksMany(t *testing.T) {
 {"a":"2"}
 {"a":"3"}
 `)
-	eventBuff := make([]byte, 0, 0)
+	eventBuff := make([]byte, 0)
 	eventBuff = input.processChunk(0, chunk, eventBuff)
 
 	wg.Wait()
@@ -65,7 +65,7 @@ func TestProcessChunksEventBuff(t *testing.T) {
 	wg := &sync.WaitGroup{}
 	wg.Add(2)
 
-	outEvents := make([]string, 0, 0)
+	outEvents := make([]string, 0)
 	output.SetOutFn(func(event *pipeline.Event) {
 		outEvents = append(outEvents, event.Root.EncodeToString())
 		wg.Done()
@@ -74,7 +74,7 @@ func TestProcessChunksEventBuff(t *testing.T) {
 	chunk := []byte(`{"a":"1"}
 {"a":"2"}
 {"a":"3"}`)
-	eventBuff := make([]byte, 0, 0)
+	eventBuff := make([]byte, 0)
 	eventBuff = input.processChunk(0, chunk, eventBuff)
 
 	wg.Wait()
@@ -95,7 +95,7 @@ func TestProcessChunksContinue(t *testing.T) {
 	wg := &sync.WaitGroup{}
 	wg.Add(3)
 
-	outEvents := make([]string, 0, 0)
+	outEvents := make([]string, 0)
 	output.SetOutFn(func(event *pipeline.Event) {
 		outEvents = append(outEvents, event.Root.EncodeToString())
 		wg.Done()
@@ -127,7 +127,7 @@ func TestProcessChunksContinueMany(t *testing.T) {
 	wg := &sync.WaitGroup{}
 	wg.Add(1)
 
-	outEvents := make([]string, 0, 0)
+	outEvents := make([]string, 0)
 	output.SetOutFn(func(event *pipeline.Event) {
 		outEvents = append(outEvents, event.Root.EncodeToString())
 		wg.Done()

--- a/plugin/input/k8s/k8s_test.go
+++ b/plugin/input/k8s/k8s_test.go
@@ -122,7 +122,7 @@ func TestAllowedLabels(t *testing.T) {
 	putMeta(getPodInfo(item, false))
 	filename2 := getLogFilename("/k8s-logs", item)
 
-	outEvents := make([]*pipeline.Event, 0, 0)
+	outEvents := make([]*pipeline.Event, 0)
 	output.SetOutFn(func(e *pipeline.Event) {
 		outEvents = append(outEvents, e)
 		wg.Done()
@@ -153,7 +153,7 @@ func TestK8SJoin(t *testing.T) {
 	podInfo := getPodInfo(item, true)
 	putMeta(podInfo)
 
-	outEvents := make([]*pipeline.Event, 0, 0)
+	outEvents := make([]*pipeline.Event, 0)
 	output.SetOutFn(func(e *pipeline.Event) {
 		event := *e
 		outEvents = append(outEvents, &event)

--- a/plugin/output/file/file.go
+++ b/plugin/output/file/file.go
@@ -46,7 +46,7 @@ type data struct {
 }
 
 const (
-	outPluginType ="file"
+	outPluginType = "file"
 
 	fileNameSeparator = "_"
 )
@@ -207,6 +207,9 @@ func (p *Plugin) createNew() {
 	f := fmt.Sprintf("%s%s", p.targetDir, p.tsFileName)
 	pattern := fmt.Sprintf("%s*%s%s%s", p.targetDir, fileNameSeparator, p.fileName, p.fileExtension)
 	matches, err := filepath.Glob(pattern)
+	if err != nil {
+		p.logger.Fatalf("can't glob: pattern=%s, err=%ss", pattern, err.Error())
+	}
 	if len(matches) == 1 {
 		p.tsFileName = path.Base(matches[0])
 		f = fmt.Sprintf("%s%s", p.targetDir, p.tsFileName)

--- a/plugin/output/file/file_test.go
+++ b/plugin/output/file/file_test.go
@@ -261,13 +261,6 @@ func TestStart(t *testing.T) {
 	assert.GreaterOrEqual(t, len(matches), 2, "there is no new file after sealing up")
 	checkDirFiles(t, matches, totalSent, "written data and saved data are not equal")
 
-	for _, m := range matches {
-		if strings.Contains(m, currentLogFileSubstr) {
-			tsFileName = m
-			break
-		}
-	}
-
 	// send next pack. And stop pipeline before next seal up time
 	totalSent += test.SendPack(t, p, tests.secondPack)
 	time.Sleep(writeFileSleep)

--- a/plugin/output/gelf/gelf.go
+++ b/plugin/output/gelf/gelf.go
@@ -194,7 +194,7 @@ func (p *Plugin) out(workerData *pipeline.WorkerData, batch *pipeline.Batch) {
 	if *workerData == nil {
 		*workerData = &data{
 			outBuf:    make([]byte, 0, p.config.BatchSize_*p.avgEventSize),
-			encodeBuf: make([]byte, 0, 0),
+			encodeBuf: make([]byte, 0),
 		}
 	}
 

--- a/plugin/output/kafka/kafka.go
+++ b/plugin/output/kafka/kafka.go
@@ -116,7 +116,7 @@ func (p *Plugin) Out(event *pipeline.Event) {
 func (p *Plugin) out(workerData *pipeline.WorkerData, batch *pipeline.Batch) {
 	if *workerData == nil {
 		*workerData = &data{
-			messages: make([]*sarama.ProducerMessage, p.config.BatchSize_, p.config.BatchSize_),
+			messages: make([]*sarama.ProducerMessage, p.config.BatchSize_),
 			outBuf:   make([]byte, 0, p.config.BatchSize_*p.avgEventSize),
 		}
 	}

--- a/plugin/output/s3/compress_test.go
+++ b/plugin/output/s3/compress_test.go
@@ -2,6 +2,7 @@ package s3
 
 import (
 	"archive/zip"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -79,6 +80,9 @@ func TestCompress(t *testing.T) {
 		assert.NoError(t, err)
 		sw := simpleWriter{}
 		written, err := io.CopyN(sw, closer, int64(len(logStr)))
+		assert.Error(t, err)
+		assert.EqualError(t, errors.New("short write"), err.Error())
+
 		assert.Equal(t, int64(0), written)
 		err = closer.Close()
 		assert.NoError(t, err)

--- a/test/test.go
+++ b/test/test.go
@@ -71,7 +71,7 @@ func startCasePipeline(act func(pipeline *pipeline.Pipeline), out func(event *pi
 		if x.Load() <= 0 {
 			break
 		}
-		if time.Now().Sub(t) > time.Second*10 {
+		if time.Since(t) > time.Second*10 {
 			panic("too long act")
 		}
 	}
@@ -87,7 +87,7 @@ func WaitForEvents(x *atomic.Int32) {
 		if x.Load() <= 0 {
 			break
 		}
-		if time.Now().Sub(t) > time.Second*10 {
+		if time.Since(t) > time.Second*10 {
 			panic("too long wait")
 		}
 	}


### PR DESCRIPTION
Fix parse_es, so process no longer crushes on invalid elastic search query, it's goes to discard now.
Also add some refactoring dictated by golangci-lint.